### PR TITLE
Make patched datetime.datetime.now raise a NotImplementedError

### DIFF
--- a/freezefrog/__init__.py
+++ b/freezefrog/__init__.py
@@ -49,7 +49,10 @@ class FakeDateTime(with_metaclass(FakeDateTimeMeta, real_datetime)):
 
     @classmethod
     def now(cls, *args, **kwargs):
-        raise NotImplementedError('mocked {}.now() is not implemented yet'.format(cls.__name__))
+        raise NotImplementedError(
+            'mocked {}.now() is not implemented yet'.format(cls.__name__)
+        )
+
 
 class FakeFixedDateTime(FakeDateTime):
     @classmethod

--- a/freezefrog/__init__.py
+++ b/freezefrog/__init__.py
@@ -50,7 +50,7 @@ class FakeDateTime(with_metaclass(FakeDateTimeMeta, real_datetime)):
     @classmethod
     def now(cls, *args, **kwargs):
         raise NotImplementedError(
-            'mocked {}.now() is not implemented yet'.format(cls.__name__)
+            '{}.now() is not implemented yet'.format(cls.__name__)
         )
 
 

--- a/freezefrog/__init__.py
+++ b/freezefrog/__init__.py
@@ -41,6 +41,10 @@ class FakeDateTime(with_metaclass(FakeDateTimeMeta, real_datetime)):
             cls._start = real_datetime.utcnow()
         return (real_datetime.utcnow() - cls._start) + cls.dt
 
+    @classmethod
+    def now(cls, *args, **kwargs):
+        raise NotImplementedError('use {}.utcnow() instead'.format(cls.__name__))
+
 class FakeFixedDateTime(FakeDateTime):
     @classmethod
     def _utcnow(cls):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -24,3 +24,13 @@ class FreezeFrogTestCase(unittest.TestCase):
             dt = datetime.datetime.utcnow()
             self.assertTrue(datetime.datetime(2014, 1, 1) < dt < datetime.datetime(2014, 1, 1, 0, 0, 1))
             self.assertTrue(1388534400 < time.time() < 1388534401)
+
+    def test_now(self):
+        """
+        utcnow() should always be preferred over now() and hence now() should
+        raise an error.
+        """
+        regular_now = datetime.datetime.now()
+        self.assertTrue(regular_now)
+        with FreezeTime(datetime.datetime(2014, 1, 1)):
+            self.assertRaises(NotImplementedError, datetime.datetime.now)


### PR DESCRIPTION
...since we should always prefer `utcnow()` over `now()`. Currently `now()` returns an unmocked datetime, which is very confusing.

Fixes #1 
