### PR TITLE
Ability to use `datetime.datetime.now()` with an explicitly given `tz_delta`.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,8 @@ goal is to be simple and fast.
 
 * FreezeFrog currently supports mocking the following basic methods:
 
+  * ``datetime.datetime.now`` (if ``tz_delta`` is specified)
+
   * ``datetime.datetime.utcnow``
 
   * ``time.time``

--- a/freezefrog/__init__.py
+++ b/freezefrog/__init__.py
@@ -106,7 +106,7 @@ class FreezeTime(object):
         )
 
         datetime_cls.set_utcnow(dt)
-        if tz_delta:
+        if tz_delta is not None:
             datetime_cls.set_tz_delta(tz_delta)
 
     def __enter__(self):

--- a/freezefrog/__init__.py
+++ b/freezefrog/__init__.py
@@ -53,7 +53,7 @@ class FakeDateTime(with_metaclass(FakeDateTimeMeta, real_datetime)):
 
     @classmethod
     def now(cls, *args, **kwargs):
-        if cls.tz_delta:
+        if hasattr(cls, 'tz_delta'):
             return cls.utcnow() + cls.tz_delta
         else:
             raise Exception(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -51,5 +51,12 @@ class FreezeFrogTestCase(unittest.TestCase):
     def test_now(self):
         regular_now = datetime.datetime.now()
         self.assertTrue(regular_now)
-        with FreezeTime(datetime.datetime(2014, 1, 1)):
-            self.assertRaises(NotImplementedError, datetime.datetime.now)
+
+        with FreezeTime(PAST_DATETIME):
+            self.assertRaises(Exception, datetime.datetime.now)
+
+        tz_delta = datetime.timedelta(hours=5)
+
+        with FreezeTime(PAST_DATETIME, tz_delta=tz_delta):
+            dt = datetime.datetime.now()
+            self.assertEqual(dt, PAST_DATETIME + tz_delta)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -55,6 +55,12 @@ class FreezeFrogTestCase(unittest.TestCase):
         with FreezeTime(PAST_DATETIME):
             self.assertRaises(Exception, datetime.datetime.now)
 
+        tz_delta = datetime.timedelta()
+
+        with FreezeTime(PAST_DATETIME, tz_delta=tz_delta):
+            dt = datetime.datetime.now()
+            self.assertEqual(dt, PAST_DATETIME)
+
         tz_delta = datetime.timedelta(hours=5)
 
         with FreezeTime(PAST_DATETIME, tz_delta=tz_delta):


### PR DESCRIPTION
See https://github.com/closeio/freezefrog/commit/b3a6ca03b82fc10bb0ef61223227cb58ebddffec for discussion.

I picked `Exception` as the exception to raise because it's not as easily caught as e.g. `ValueError`, and there wasn't really a suitable more specific exception type.