### PR TITLE
Pass on __exit__ args in FreezeTime

### DIFF
--- a/freezefrog/__init__.py
+++ b/freezefrog/__init__.py
@@ -122,6 +122,6 @@ class FreezeTime(object):
 
     def __exit__(self, *args):
         for p in reversed(self.patches):
-            p.__exit__()
+            p.__exit__(*args)
 
         self.datetime_cls.set_tz_delta(None)


### PR DESCRIPTION
I encountered this while debugging an issue with TaskTiger.