### PR TITLE
Make FreezeFrog simulate system naive datetime and tz

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ defaults: &defaults
     - checkout
     - run:
         name: Install dependencies
-        command: sudo pip install flake8 pytest pytz
+        command: sudo pip install flake8 pytest pytz python-dateutil
     - run:
         name: Lint
         command: flake8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ workflows:
   version: 2
   workflow:
     jobs:
-      - test-3.4
       - test-3.5
       - test-3.6
       - test-3.7
@@ -25,10 +24,6 @@ defaults: &defaults
         command: python setup.py test
 
 jobs:
-  test-3.4:
-    <<: *defaults
-    docker:
-      - image: circleci/python:3.4
   test-3.5:
     <<: *defaults
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ workflows:
   version: 2
   workflow:
     jobs:
-      - test-3.5
       - test-3.6
       - test-3.7
       - test-3.8
@@ -24,10 +23,6 @@ defaults: &defaults
         command: python setup.py test
 
 jobs:
-  test-3.5:
-    <<: *defaults
-    docker:
-      - image: circleci/python:3.5
   test-3.6:
     <<: *defaults
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,34 +4,44 @@ workflows:
   version: 2
   workflow:
     jobs:
-      - test-2.7
       - test-3.4
       - test-3.5
+      - test-3.6
+      - test-3.7
+      - test-3.8
 
 defaults: &defaults
   working_directory: ~/code
   steps:
-  - checkout
-  - run:
-      name: Install dependencies
-      command: sudo pip install flake8 pytest pytz
-  - run:
-      name: Lint
-      command: flake8
-  - run:
-      name: Test
-      command: python setup.py test
+    - checkout
+    - run:
+        name: Install dependencies
+        command: sudo pip install flake8 pytest pytz
+    - run:
+        name: Lint
+        command: flake8
+    - run:
+        name: Test
+        command: python setup.py test
 
 jobs:
-  test-2.7:
-    <<: *defaults
-    docker:
-    - image: circleci/python:2.7
   test-3.4:
     <<: *defaults
     docker:
-    - image: circleci/python:3.4
+      - image: circleci/python:3.4
   test-3.5:
     <<: *defaults
     docker:
-    - image: circleci/python:3.5
+      - image: circleci/python:3.5
+  test-3.6:
+    <<: *defaults
+    docker:
+      - image: circleci/python:3.6
+  test-3.7:
+    <<: *defaults
+    docker:
+      - image: circleci/python:3.7
+  test-3.8:
+    <<: *defaults
+    docker:
+      - image: circleci/python:3.8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ defaults: &defaults
   - checkout
   - run:
       name: Install dependencies
-      command: sudo pip install flake8 pytest
+      command: sudo pip install flake8 pytest pytz
   - run:
       name: Lint
       command: flake8

--- a/README.rst
+++ b/README.rst
@@ -35,10 +35,10 @@ Usage
 
 Use the ``FreezeTime`` context manager to freeze the time. Pass the desired
 ``datetime`` object to the constructor, and the timezone to mock the system's
-timezone. The constructor also takes the ``tick`` argument (``False`` by
-default), which makes the clock start ticking, and the ``fold`` argument (``0``
-by default), which defines whether an ambiguous time refers to its first or
-second appearance.
+timezone. The constructor also takes the ``fold`` argument (``0`` by default),
+which defines whether an ambiguous time refers to its first or second
+appearance, and the ``tick`` argument (``False`` by default), which makes the
+clock start ticking.
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,8 @@ is to be simple and fast.
 
   * ``time.time``
 
+* FreezeFrog supports both `datetime` and `pytz` timezone objects.
+
 Usage
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -53,9 +53,9 @@ clock start ticking.
   with FreezeTime(datetime.datetime(2014, 1, 1), UTC):
       # The clock is frozen.
       # Always prints 2014-01-01 00:00:00
-      print datetime.datetime.utcnow()
+      print(datetime.datetime.utcnow())
 
   with FreezeTime(datetime.datetime(2014, 1, 1), UTC, tick=True):
       # The clock starts ticking immediately.
       # Example output: 2014-01-01 00:00:00.000005
-      print datetime.datetime.utcnow()
+      print(datetime.datetime.utcnow())

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ is to be simple and fast.
 
   * ``time.time``
 
-* FreezeFrog supports both `datetime` and `pytz` timezone objects.
+* FreezeFrog supports both ``datetime`` and ``pytz`` timezone objects.
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -4,54 +4,55 @@ FreezeFrog
 .. image:: https://circleci.com/gh/closeio/freezefrog/tree/master.svg?style=svg&circle-token=010565a97316df8a248f0f32d584357021a3873b
     :target: https://circleci.com/gh/closeio/freezefrog/tree/master
 
-*FreezeFrog* lets you efficiently mock datetimes in unit tests.
+*FreezeFrog* lets you mock datetimes in tests.
 
-
-(Interested in working on projects like this? `Close.io`_ is looking for `great engineers`_ to join our team)
+(Interested in working on projects like this? `Close.io`_ is looking for `great engineers`_ to join our team.)
 
 .. _Close.io: http://close.io
 .. _great engineers: http://jobs.close.io
 
-
 .. contents:: Contents
-
 
 Why FreezeFrog?
 ---------------
 
-FreezeFrog is a Python library that lets you mock datetimes in unit tests. Its
-goal is to be simple and fast.
+FreezeFrog is a Python library that lets you mock datetimes in tests. Its goal
+is to be simple and fast.
 
-* In comparison to certain other time freezing libraries, FreezeFrog doesn't loop
-  through all imported modules, making it fast even for larger projects.
+* In comparison to certain other time freezing libraries, FreezeFrog doesn't
+  loop through all imported modules, making it fast even for larger projects.
 
 * FreezeFrog currently supports mocking the following basic methods:
 
-  * ``datetime.datetime.now`` (if ``tz_delta`` is specified)
+  * ``datetime.datetime.now``
 
   * ``datetime.datetime.utcnow``
 
   * ``time.time``
 
-
 Usage
 -----
 
 Use the ``FreezeTime`` context manager to freeze the time. Pass the desired
-``datetime`` object to the constructor. The constructor also takes the ``tick``
-keyword argument (``False`` by default), which makes the clock start ticking.
+``datetime`` object to the constructor, and the timezone to mock the system's
+timezone. The constructor also takes the ``tick`` argument (``False`` by
+default), which makes the clock start ticking, and the ``fold`` argument, which
+defines whether an ambiguous time refers to its first or second appearance.
 
 .. code:: python
 
-  from freezefrog import FreezeTime
   import datetime
 
-  with FreezeTime(datetime.datetime(2014, 1, 1)):
+  from freezefrog import FreezeTime
+
+  UTC = datetime.timezone.utc
+
+  with FreezeTime(datetime.datetime(2014, 1, 1), UTC):
       # The clock is frozen.
       # Always prints 2014-01-01 00:00:00
       print datetime.datetime.utcnow()
 
-  with FreezeTime(datetime.datetime(2014, 1, 1), tick=True):
+  with FreezeTime(datetime.datetime(2014, 1, 1), UTC, tick=True):
       # The clock starts ticking immediately.
       # Example output: 2014-01-01 00:00:00.000005
       print datetime.datetime.utcnow()

--- a/README.rst
+++ b/README.rst
@@ -36,8 +36,9 @@ Usage
 Use the ``FreezeTime`` context manager to freeze the time. Pass the desired
 ``datetime`` object to the constructor, and the timezone to mock the system's
 timezone. The constructor also takes the ``tick`` argument (``False`` by
-default), which makes the clock start ticking, and the ``fold`` argument, which
-defines whether an ambiguous time refers to its first or second appearance.
+default), which makes the clock start ticking, and the ``fold`` argument (``0``
+by default), which defines whether an ambiguous time refers to its first or
+second appearance.
 
 .. code:: python
 

--- a/freezefrog/__init__.py
+++ b/freezefrog/__init__.py
@@ -25,7 +25,7 @@ def get_pytz_dst_from_fold(dt, tz, fold):
     obvious:
 
     datetime's `fold` lets you say you want either the earlier time
-    (fold=0) or the later time (fold=1) in a DST.
+    (fold=0) or the later time (fold=1) during the DST transition period.
 
     pytz's `is_dst` lets you say whether you want to time that was inside the
     DST interval (the non-standard timezone offset for that region), or outside

--- a/freezefrog/__init__.py
+++ b/freezefrog/__init__.py
@@ -76,7 +76,7 @@ class FakeDateTime(with_metaclass(FakeDateTimeMeta, real_datetime)):
     _start = None
 
     @classmethod
-    def start(cls, dt, tz, tick, fold):
+    def start(cls, dt, tz, fold, tick):
         cls.dt = dt
         cls.tz = tz
         cls._start = time.monotonic() if tick else None
@@ -158,8 +158,8 @@ class FreezeTime(object):
         self,
         dt,
         tz,
-        tick=False,
         fold=0,
+        tick=False,
         extra_patch_datetime=(),
         extra_patch_time=(),
     ):
@@ -172,12 +172,12 @@ class FreezeTime(object):
 
         self._dt = dt
         self._tz = tz
-        self._tick = tick
         self._fold = fold
+        self._tick = tick
 
     def __enter__(self):
         FakeDateTime.start(
-            self._dt, self._tz, tick=self._tick, fold=self._fold
+            self._dt, self._tz, fold=self._fold, tick=self._tick
         )
 
         for p in self.patches:

--- a/freezefrog/__init__.py
+++ b/freezefrog/__init__.py
@@ -88,50 +88,50 @@ class FakeDateTime(with_metaclass(FakeDateTimeMeta, real_datetime)):
                 )
 
             cls.is_dst = get_pytz_dst_from_fold(dt, tz, fold)
-            cls.now = cls.now_with_pytz
-            cls.utcnow = cls.utcnow_with_pytz
+            cls.now = cls._now_with_pytz
+            cls.utcnow = cls._utcnow_with_pytz
         else:
             cls.fold = fold
-            cls.now = cls.now_with_datetime_tz
-            cls.utcnow = cls.utcnow_with_datetime_tz
+            cls.now = cls._now_with_datetime_tz
+            cls.utcnow = cls._utcnow_with_datetime_tz
 
     @classmethod
-    def time_since_start(cls):
+    def _time_since_start(cls):
         if cls._start is None:
             return datetime.timedelta(seconds=0)
         return datetime.timedelta(seconds=time.monotonic() - cls._start)
 
     @classmethod
-    def now_with_datetime_tz(cls, tz=None):
+    def _now_with_datetime_tz(cls, tz=None):
         if tz is None:
-            return cls.dt + cls.time_since_start()
+            return cls.dt + cls._time_since_start()
         return (
             cls.dt.replace(tzinfo=cls.tz, fold=cls.fold).astimezone(
                 datetime.timezone.utc
             )
-            + cls.time_since_start()
+            + cls._time_since_start()
         ).astimezone(tz)
 
     @classmethod
-    def now_with_pytz(cls, tz=None):
+    def _now_with_pytz(cls, tz=None):
         if tz is None:
-            return cls.dt + cls.time_since_start()
+            return cls.dt + cls._time_since_start()
         return tz.normalize(
             pytz.UTC.normalize(cls.tz.localize(cls.dt, is_dst=cls.is_dst))
-            + cls.time_since_start()
+            + cls._time_since_start()
         )
+
+    @classmethod
+    def _utcnow_with_datetime_tz(cls):
+        return cls.now(tz=datetime.timezone.utc).replace(tzinfo=None)
+
+    @classmethod
+    def _utcnow_with_pytz(cls):
+        return cls.now(tz=pytz.UTC).replace(tzinfo=None)
 
     @classmethod
     def today(cls):
         return cls.now()
-
-    @classmethod
-    def utcnow_with_datetime_tz(cls):
-        return cls.now(tz=datetime.timezone.utc).replace(tzinfo=None)
-
-    @classmethod
-    def utcnow_with_pytz(cls):
-        return cls.now(tz=pytz.UTC).replace(tzinfo=None)
 
 
 def fake_time():

--- a/freezefrog/__init__.py
+++ b/freezefrog/__init__.py
@@ -1,10 +1,6 @@
 import datetime
 import time
-
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 try:
     import pytz

--- a/freezefrog/__init__.py
+++ b/freezefrog/__init__.py
@@ -1,12 +1,14 @@
-import calendar
 import datetime
+import time
+
+import pytz
 
 try:
     from unittest.mock import patch
 except ImportError:
     from mock import patch
 
-__all__ = ['FreezeTime']
+__all__ = ["FreezeTime"]
 
 
 real_datetime = datetime.datetime
@@ -28,94 +30,79 @@ class FakeDateTimeMeta(type):
 
 class FakeDateTime(with_metaclass(FakeDateTimeMeta, real_datetime)):
     """
-    A datetime replacement that lets you set utcnow() using set_utcnow().
+    A `datetime` mock class.
 
-    The clock starts ticking after calling set_utcnow().
+    Set the start datetime and the system timezone with `start(dt, tz)`. The
+    clock starts ticking after calling `start`.
     """
-    tz_delta = None
+
+    dt = None
+    tz = None
+    _start = None
 
     @classmethod
-    def utcnow(cls, *args, **kwargs):
-        if not hasattr(cls, 'dt'):
-            raise NotImplementedError(
-                'use {}.set_utcnow(datetime) first'.format(cls.__name__)
-            )
-        return cls._utcnow()
-
-    @classmethod
-    def set_utcnow(cls, dt):
+    def start(cls, dt, tz, tick):
         cls.dt = dt
+        cls.tz = tz
+        cls._start = time.monotonic() if tick else None
 
     @classmethod
-    def set_tz_delta(cls, tz_delta):
-        cls.tz_delta = tz_delta
+    def time_since_start(cls):
+        if cls._start is None:
+            return datetime.timedelta(seconds=0)
+        return datetime.timedelta(seconds=time.monotonic() - cls._start)
 
     @classmethod
-    def _utcnow(cls):
-        if not hasattr(cls, '_start'):
-            cls._start = real_datetime.utcnow()
-        return (real_datetime.utcnow() - cls._start) + cls.dt
+    def now(cls, tz=None):
+        if tz is None:
+            return cls.dt + cls.time_since_start()
+        return tz.normalize(cls.tz.localize(cls.dt) + cls.time_since_start())
 
     @classmethod
-    def now(cls, *args, **kwargs):
-        if cls.tz_delta is not None:
-            return cls.utcnow() + cls.tz_delta
-        else:
-            raise Exception(
-                '{}.now() requires setting tz_delta'.format(cls.__name__)
-            )
+    def today(cls):
+        return cls.now()
 
-
-class FakeFixedDateTime(FakeDateTime):
     @classmethod
-    def _utcnow(cls):
-        return cls.dt
+    def utcnow(cls):
+        return cls.now(tz=pytz.utc)
 
 
 def fake_time():
-    now = datetime.datetime.utcnow()
-    ts = calendar.timegm(now.timetuple())
-    ts += now.microsecond / 1e6
-    return ts
+    return FakeDateTime.tz.localize(datetime.datetime.now()).timestamp()
 
 
 class FreezeTime(object):
     """
     A context manager that freezes the datetime to the given datetime object.
 
-    If tick=True is passed, the clock will start ticking, otherwise the clock
-    will remain at the given datetime.
+    It simulates that the system timezone is the passed timezone.
 
-    If `tz_delta` is passed, `datetime.datetime.now()` can be used with the
-    given UTC delta which is added to the frozen datetime.
+    If `tick=True` is passed, the clock will tick, otherwise the clock will
+    remain at the given datetime.
 
     Additional patch targets can be passed via `extra_patch_datetime` and
-    `extra_patch_time` to patch the datetime class or time function if it was
-    already imported in a different module. For example, if module `x` contains
-    `from datetime import datetime` (as opposed to `import datetime`), it needs
-    to be patched separately (`extra_patch_datetime=['x.datetime']`).
+    `extra_patch_time` to patch the `datetime` class or `time` function if it
+    was already imported in a different module. For example, if module `x`
+    contains `from datetime import datetime` (as opposed to `import datetime`),
+    it needs to be patched separately (`extra_patch_datetime=['x.datetime']`).
     """
-    def __init__(self, dt, tick=False, extra_patch_datetime=[],
-                 extra_patch_time=[], tz_delta=None):
-        datetime_targets = ['datetime.datetime'] + extra_patch_datetime
-        time_targets = ['time.time'] + extra_patch_time
 
-        if tick:
-            self.datetime_cls = FakeDateTime
-        else:
-            self.datetime_cls = FakeFixedDateTime
+    def __init__(
+        self, dt, tz, tick=False, extra_patch_datetime=(), extra_patch_time=()
+    ):
+        datetime_targets = ("datetime.datetime",) + tuple(extra_patch_datetime)
+        time_targets = ("time.time",) + tuple(extra_patch_time)
 
-        self.patches = (
-            [patch(target, self.datetime_cls) for target in datetime_targets] +
-            [patch(target, fake_time) for target in time_targets]
-        )
+        self.patches = [
+            patch(target, FakeDateTime) for target in datetime_targets
+        ] + [patch(target, fake_time) for target in time_targets]
 
-        self.datetime_cls.set_utcnow(dt)
-
-        self.tz_delta = tz_delta
+        self._dt = dt
+        self._tz = tz
+        self._tick = tick
 
     def __enter__(self):
-        self.datetime_cls.set_tz_delta(self.tz_delta)
+        FakeDateTime.start(self._dt, self._tz, tick=self._tick)
 
         for p in self.patches:
             p.__enter__()
@@ -123,5 +110,3 @@ class FreezeTime(object):
     def __exit__(self, *args):
         for p in reversed(self.patches):
             p.__exit__(*args)
-
-        self.datetime_cls.set_tz_delta(None)

--- a/freezefrog/__init__.py
+++ b/freezefrog/__init__.py
@@ -91,13 +91,14 @@ class FakeDateTime(with_metaclass(FakeDateTimeMeta, real_datetime)):
     @classmethod
     def _time_since_start(cls):
         if cls._start is None:
-            return datetime.timedelta(seconds=0)
+            return datetime.timedelta()
         return datetime.timedelta(seconds=time.monotonic() - cls._start)
 
     @classmethod
     def now(cls, tz=None):
         if tz is None:
             return cls.dt + cls._time_since_start()
+        # This is equivalent to Python's own implementation of `now`.
         return tz.fromutc(
             (cls.dt_in_utc + cls._time_since_start()).replace(tzinfo=tz)
         )

--- a/freezefrog/__init__.py
+++ b/freezefrog/__init__.py
@@ -64,7 +64,7 @@ class FakeDateTime(with_metaclass(FakeDateTimeMeta, real_datetime)):
 
     @classmethod
     def utcnow(cls):
-        return cls.now(tz=pytz.UTC)
+        return cls.now(tz=pytz.UTC).replace(tzinfo=None)
 
 
 def fake_time():

--- a/freezefrog/__init__.py
+++ b/freezefrog/__init__.py
@@ -74,7 +74,7 @@ class FakeDateTime(with_metaclass(FakeDateTimeMeta, real_datetime)):
     _start = None
 
     @classmethod
-    def start(cls, dt, tz, fold, tick):
+    def _initialize(cls, dt, tz, fold, tick):
         cls.dt = dt
         cls.tz = tz
         cls._start = time.monotonic() if tick else None
@@ -153,7 +153,7 @@ class FreezeTime(object):
         self._tick = tick
 
     def __enter__(self):
-        FakeDateTime.start(
+        FakeDateTime._initialize(
             self._dt, self._tz, fold=self._fold, tick=self._tick
         )
 

--- a/freezefrog/__init__.py
+++ b/freezefrog/__init__.py
@@ -98,9 +98,9 @@ class FakeDateTime(with_metaclass(FakeDateTimeMeta, real_datetime)):
     def now(cls, tz=None):
         if tz is None:
             return cls.dt + cls._time_since_start()
-        if is_pytz(tz):
-            return tz.normalize(cls.dt_in_utc + cls._time_since_start())
-        return (cls.dt_in_utc + cls._time_since_start()).astimezone(tz)
+        return tz.fromutc(
+            (cls.dt_in_utc + cls._time_since_start()).replace(tzinfo=tz)
+        )
 
     @classmethod
     def today(cls):

--- a/freezefrog/__init__.py
+++ b/freezefrog/__init__.py
@@ -64,7 +64,7 @@ class FakeDateTime(with_metaclass(FakeDateTimeMeta, real_datetime)):
 
     @classmethod
     def utcnow(cls):
-        return cls.now(tz=pytz.utc)
+        return cls.now(tz=pytz.UTC)
 
 
 def fake_time():

--- a/freezefrog/__init__.py
+++ b/freezefrog/__init__.py
@@ -7,14 +7,14 @@ try:
 except ImportError:
     pass
 
-__all__ = ["FreezeTime"]
+__all__ = ['FreezeTime']
 
 
 real_datetime = datetime.datetime
 
 
 def is_pytz(tz):
-    return hasattr(tz, "localize")
+    return hasattr(tz, 'localize')
 
 
 def get_pytz_dst_from_fold(dt, tz, fold):
@@ -50,7 +50,7 @@ def get_pytz_dst_from_fold(dt, tz, fold):
 # From six
 def with_metaclass(meta, *bases):
     """Create a base class with a metaclass."""
-    return meta("NewBase", bases, {})
+    return meta('NewBase', bases, {})
 
 
 # Adapted from freezegun. This metaclass will make sure that calls to
@@ -141,8 +141,8 @@ class FreezeTime(object):
         extra_patch_datetime=(),
         extra_patch_time=(),
     ):
-        datetime_targets = ("datetime.datetime",) + tuple(extra_patch_datetime)
-        time_targets = ("time.time",) + tuple(extra_patch_time)
+        datetime_targets = ('datetime.datetime',) + tuple(extra_patch_datetime)
+        time_targets = ('time.time',) + tuple(extra_patch_time)
 
         self.patches = [
             patch(target, FakeDateTime) for target in datetime_targets

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-# workaround for open() with encoding='' python2/3 compability
-from io import open
 from setuptools import setup
 
 with open('README.rst', encoding='utf-8') as file:
@@ -7,20 +5,18 @@ with open('README.rst', encoding='utf-8') as file:
 
 setup(
     name='freezefrog',
-    version='0.3.2',
+    version='0.4.0',
     url='http://github.com/closeio/freezefrog',
     license='MIT',
     author='Thomas Steinacher',
     author_email='engineering@close.io',
     maintainer='Thomas Steinacher',
     maintainer_email='engineering@close.io',
-    description='Efficient datetime mocking in tests',
+    description='Datetime mocking in tests',
     long_description=long_description,
     test_suite='tests',
     platforms='any',
-    install_requires=[
-        'mock>=2.0.0;python_version<"3"',
-    ],
+    install_requires=[],
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -208,3 +208,18 @@ class FreezeFrogTestCase(unittest.TestCase):
                 .replace(tzinfo=None),
             )
             self.assertEqual(time.time(), timestamp_later)
+
+    def test_cross_library_timezones(self):
+        dt = datetime.datetime(2014, 1, 1)
+        NYC_datetime = dateutil.tz.gettz("America/New_York")
+        NYC_pytz = pytz.timezone("America/New_York")
+
+        for tz in [NYC_datetime, NYC_pytz]:
+            with FreezeTime(dt, tz):
+                self.assertEqual(
+                    datetime.datetime.now(NYC_datetime),
+                    dt.replace(tzinfo=NYC_datetime),
+                )
+                self.assertEqual(
+                    datetime.datetime.now(NYC_pytz), NYC_pytz.localize(dt)
+                )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,72 +1,112 @@
 import datetime
-from freezefrog import FreezeTime
 import time
 import unittest
 
+import pytz
+
+from freezefrog import FreezeTime
+
 PAST_DATETIME = datetime.datetime(2014, 1, 1)
-PAST_TIME = 1388534400
+PAST_TIME_UTC_TIMESTAMP = 1388534400
+PAST_TIME_NEW_YORK_TIMESTAMP = 1388552400
+TEN_SEC_DELTA = datetime.timedelta(seconds=10)
 
 
 class FreezeFrogTestCase(unittest.TestCase):
-    def test_freeze(self):
-        dt = datetime.datetime.utcnow()
+    def test_freeze_no_tick_utc(self):
+        utc_localized_past_datetime = pytz.UTC.localize(PAST_DATETIME)
+
+        dt = datetime.datetime.now()
         self.assertTrue(dt > datetime.datetime(2016, 1, 1))
 
-        with FreezeTime(PAST_DATETIME):
+        with FreezeTime(PAST_DATETIME, pytz.UTC):
+            self.assertTrue(
+                isinstance(datetime.datetime.now(), datetime.datetime)
+            )
+
             time.sleep(0.001)
-            dt = datetime.datetime.utcnow()
-            self.assertEqual(dt, PAST_DATETIME)
-            self.assertTrue(isinstance(dt, datetime.datetime))
-            self.assertEqual(time.time(), PAST_TIME)
+            self.assertEqual(datetime.datetime.now(), PAST_DATETIME)
+            self.assertEqual(datetime.datetime.today(), PAST_DATETIME)
+            self.assertEqual(
+                datetime.datetime.utcnow(), utc_localized_past_datetime
+            )
 
-        dt = datetime.datetime.utcnow()
+            self.assertEqual(
+                datetime.datetime.now(pytz.UTC),
+                pytz.UTC.localize(PAST_DATETIME),
+            )
+
+            self.assertEqual(time.time(), PAST_TIME_UTC_TIMESTAMP)
+
+        dt = datetime.datetime.now()
         self.assertTrue(dt > datetime.datetime(2016, 1, 1))
+
+    def test_freeze_tick_utc(self):
+        utc_localized_past_datetime = pytz.UTC.localize(PAST_DATETIME)
+
+        dt = datetime.datetime.now()
+        self.assertTrue(dt > datetime.datetime(2016, 1, 1))
+
+        with FreezeTime(PAST_DATETIME, pytz.UTC, tick=True):
+            self.assertTrue(
+                isinstance(datetime.datetime.now(), datetime.datetime)
+            )
+
+            time.sleep(0.001)
+            self.assertTrue(
+                PAST_DATETIME
+                < datetime.datetime.now()
+                < PAST_DATETIME + TEN_SEC_DELTA
+            )
+            self.assertTrue(
+                PAST_DATETIME
+                < datetime.datetime.today()
+                < PAST_DATETIME + TEN_SEC_DELTA
+            )
+            self.assertTrue(
+                utc_localized_past_datetime
+                < datetime.datetime.utcnow()
+                < utc_localized_past_datetime + TEN_SEC_DELTA
+            )
+
+            self.assertTrue(
+                PAST_TIME_UTC_TIMESTAMP
+                < time.time()
+                < PAST_TIME_UTC_TIMESTAMP + 1
+            )
+
+        dt = datetime.datetime.now()
+        self.assertTrue(dt > datetime.datetime(2016, 1, 1))
+
+    def test_freeze_new_york(self):
+        ny_localized_past_datetime = pytz.timezone(
+            "America/New_York"
+        ).localize(PAST_DATETIME)
+        with FreezeTime(
+            PAST_DATETIME, pytz.timezone("America/New_York"), tick=True
+        ):
+            self.assertTrue(
+                ny_localized_past_datetime
+                < datetime.datetime.utcnow()
+                < ny_localized_past_datetime + TEN_SEC_DELTA
+            )
 
     def test_freeze_extra(self):
         from . import module
 
         # Doesn't work since we've imported the sample module already.
-        with FreezeTime(PAST_DATETIME):
+        with FreezeTime(PAST_DATETIME, pytz.UTC):
             t, dt = module.get_info()
-            self.assertNotEqual(t, PAST_TIME)
+            self.assertNotEqual(t, PAST_TIME_UTC_TIMESTAMP)
             self.assertNotEqual(dt, PAST_DATETIME)
 
         # Works as expected.
-        with FreezeTime(PAST_DATETIME,
-                        extra_patch_time=['tests.module.time'],
-                        extra_patch_datetime=['tests.module.datetime']):
+        with FreezeTime(
+            PAST_DATETIME,
+            pytz.UTC,
+            extra_patch_time=["tests.module.time"],
+            extra_patch_datetime=["tests.module.datetime"],
+        ):
             t, dt = module.get_info()
-            self.assertEqual(t, PAST_TIME)
+            self.assertEqual(t, PAST_TIME_UTC_TIMESTAMP)
             self.assertEqual(dt, PAST_DATETIME)
-
-    def test_freeze_tick(self):
-        with FreezeTime(PAST_DATETIME, tick=True):
-            time.sleep(0.001)
-            dt = datetime.datetime.utcnow()
-            start = PAST_DATETIME
-            end = PAST_DATETIME + datetime.timedelta(seconds=1)
-            self.assertTrue(start < dt < end)
-            self.assertTrue(PAST_TIME < time.time() < PAST_TIME+1)
-
-    def test_now(self):
-        regular_now = datetime.datetime.now()
-        self.assertTrue(regular_now)
-
-        with FreezeTime(PAST_DATETIME):
-            self.assertRaises(Exception, datetime.datetime.now)
-
-        tz_delta = datetime.timedelta()
-
-        with FreezeTime(PAST_DATETIME, tz_delta=tz_delta):
-            dt = datetime.datetime.now()
-            self.assertEqual(dt, PAST_DATETIME)
-
-        tz_delta = datetime.timedelta(hours=5)
-
-        with FreezeTime(PAST_DATETIME, tz_delta=tz_delta):
-            dt = datetime.datetime.now()
-            self.assertEqual(dt, PAST_DATETIME + tz_delta)
-
-        # check no stale tz_deltas remained
-        with FreezeTime(PAST_DATETIME):
-            self.assertRaises(Exception, datetime.datetime.now)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -14,7 +14,9 @@ TEN_SEC_DELTA = datetime.timedelta(seconds=10)
 
 class FreezeFrogTestCase(unittest.TestCase):
     def test_freeze_no_tick_utc(self):
-        utc_localized_past_datetime = pytz.UTC.localize(PAST_DATETIME)
+        utc_naive_past_datetime = pytz.UTC.localize(PAST_DATETIME).replace(
+            tzinfo=None
+        )
 
         dt = datetime.datetime.now()
         self.assertTrue(dt > datetime.datetime(2016, 1, 1))
@@ -28,7 +30,7 @@ class FreezeFrogTestCase(unittest.TestCase):
             self.assertEqual(datetime.datetime.now(), PAST_DATETIME)
             self.assertEqual(datetime.datetime.today(), PAST_DATETIME)
             self.assertEqual(
-                datetime.datetime.utcnow(), utc_localized_past_datetime
+                datetime.datetime.utcnow(), utc_naive_past_datetime
             )
 
             self.assertEqual(
@@ -42,7 +44,9 @@ class FreezeFrogTestCase(unittest.TestCase):
         self.assertTrue(dt > datetime.datetime(2016, 1, 1))
 
     def test_freeze_tick_utc(self):
-        utc_localized_past_datetime = pytz.UTC.localize(PAST_DATETIME)
+        utc_naive_past_datetime = pytz.UTC.localize(PAST_DATETIME).replace(
+            tzinfo=None
+        )
 
         dt = datetime.datetime.now()
         self.assertTrue(dt > datetime.datetime(2016, 1, 1))
@@ -64,9 +68,9 @@ class FreezeFrogTestCase(unittest.TestCase):
                 < PAST_DATETIME + TEN_SEC_DELTA
             )
             self.assertTrue(
-                utc_localized_past_datetime
+                utc_naive_past_datetime
                 < datetime.datetime.utcnow()
-                < utc_localized_past_datetime + TEN_SEC_DELTA
+                < utc_naive_past_datetime + TEN_SEC_DELTA
             )
 
             self.assertTrue(
@@ -79,16 +83,12 @@ class FreezeFrogTestCase(unittest.TestCase):
         self.assertTrue(dt > datetime.datetime(2016, 1, 1))
 
     def test_freeze_new_york(self):
-        ny_localized_past_datetime = pytz.timezone(
-            "America/New_York"
-        ).localize(PAST_DATETIME)
-        with FreezeTime(
-            PAST_DATETIME, pytz.timezone("America/New_York"), tick=True
-        ):
-            self.assertTrue(
-                ny_localized_past_datetime
-                < datetime.datetime.utcnow()
-                < ny_localized_past_datetime + TEN_SEC_DELTA
+        ny_to_utc_naive_past_datetime = pytz.UTC.normalize(
+            pytz.timezone("America/New_York").localize(PAST_DATETIME)
+        ).replace(tzinfo=None)
+        with FreezeTime(PAST_DATETIME, pytz.timezone("America/New_York")):
+            self.assertEqual(
+                datetime.datetime.utcnow(), ny_to_utc_naive_past_datetime
             )
 
     def test_freeze_extra(self):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,6 +3,7 @@ import time
 import unittest
 
 import pytz
+import dateutil.tz
 
 from freezefrog import FreezeTime
 
@@ -13,49 +14,35 @@ TEN_SEC_DELTA = datetime.timedelta(seconds=10)
 
 
 class FreezeFrogTestCase(unittest.TestCase):
-    def test_freeze_no_tick_utc(self):
-        utc_naive_past_datetime = pytz.UTC.localize(PAST_DATETIME).replace(
-            tzinfo=None
-        )
-
-        dt = datetime.datetime.now()
-        self.assertTrue(dt > datetime.datetime(2016, 1, 1))
-
+    def test_isinstance(self):
         with FreezeTime(PAST_DATETIME, pytz.UTC):
             self.assertTrue(
                 isinstance(datetime.datetime.now(), datetime.datetime)
             )
 
+    def test_freeze_no_tick(self):
+        dt = datetime.datetime.now()
+        self.assertTrue(dt > datetime.datetime(2016, 1, 1))
+
+        with FreezeTime(PAST_DATETIME, pytz.UTC):
             time.sleep(0.001)
             self.assertEqual(datetime.datetime.now(), PAST_DATETIME)
             self.assertEqual(datetime.datetime.today(), PAST_DATETIME)
-            self.assertEqual(
-                datetime.datetime.utcnow(), utc_naive_past_datetime
-            )
-
+            self.assertEqual(datetime.datetime.utcnow(), PAST_DATETIME)
             self.assertEqual(
                 datetime.datetime.now(pytz.UTC),
                 pytz.UTC.localize(PAST_DATETIME),
             )
-
             self.assertEqual(time.time(), PAST_TIME_UTC_TIMESTAMP)
 
         dt = datetime.datetime.now()
         self.assertTrue(dt > datetime.datetime(2016, 1, 1))
 
-    def test_freeze_tick_utc(self):
-        utc_naive_past_datetime = pytz.UTC.localize(PAST_DATETIME).replace(
-            tzinfo=None
-        )
-
+    def test_freeze_tick(self):
         dt = datetime.datetime.now()
         self.assertTrue(dt > datetime.datetime(2016, 1, 1))
 
         with FreezeTime(PAST_DATETIME, pytz.UTC, tick=True):
-            self.assertTrue(
-                isinstance(datetime.datetime.now(), datetime.datetime)
-            )
-
             time.sleep(0.001)
             self.assertTrue(
                 PAST_DATETIME
@@ -68,11 +55,10 @@ class FreezeFrogTestCase(unittest.TestCase):
                 < PAST_DATETIME + TEN_SEC_DELTA
             )
             self.assertTrue(
-                utc_naive_past_datetime
+                PAST_DATETIME
                 < datetime.datetime.utcnow()
-                < utc_naive_past_datetime + TEN_SEC_DELTA
+                < PAST_DATETIME + TEN_SEC_DELTA
             )
-
             self.assertTrue(
                 PAST_TIME_UTC_TIMESTAMP
                 < time.time()
@@ -82,14 +68,40 @@ class FreezeFrogTestCase(unittest.TestCase):
         dt = datetime.datetime.now()
         self.assertTrue(dt > datetime.datetime(2016, 1, 1))
 
-    def test_freeze_new_york(self):
-        ny_to_utc_naive_past_datetime = pytz.UTC.normalize(
+    def test_freeze_new_york_pytz_interface(self):
+        ny_to_utc_past_datetime = pytz.UTC.normalize(
             pytz.timezone("America/New_York").localize(PAST_DATETIME)
-        ).replace(tzinfo=None)
+        )
+        ny_to_utc_naive_past_datetime = ny_to_utc_past_datetime.replace(
+            tzinfo=None
+        )
         with FreezeTime(PAST_DATETIME, pytz.timezone("America/New_York")):
+            self.assertEqual(datetime.datetime.now(), PAST_DATETIME)
+            self.assertEqual(datetime.datetime.today(), PAST_DATETIME)
             self.assertEqual(
                 datetime.datetime.utcnow(), ny_to_utc_naive_past_datetime
             )
+            self.assertEqual(
+                datetime.datetime.now(pytz.UTC), ny_to_utc_past_datetime,
+            )
+            self.assertEqual(time.time(), PAST_TIME_NEW_YORK_TIMESTAMP)
+
+    def test_freeze_new_york_default_datetime_tz_interface(self):
+        past_datetime_in_utc = PAST_DATETIME.replace(
+            tzinfo=dateutil.tz.gettz("America/New_York")
+        ).astimezone(datetime.timezone.utc)
+        with FreezeTime(PAST_DATETIME, dateutil.tz.gettz("America/New_York")):
+            self.assertEqual(datetime.datetime.now(), PAST_DATETIME)
+            self.assertEqual(datetime.datetime.today(), PAST_DATETIME)
+            self.assertEqual(
+                datetime.datetime.utcnow(),
+                past_datetime_in_utc.replace(tzinfo=None),
+            )
+            self.assertEqual(
+                datetime.datetime.now(datetime.timezone.utc),
+                past_datetime_in_utc,
+            )
+            self.assertEqual(time.time(), PAST_TIME_NEW_YORK_TIMESTAMP)
 
     def test_freeze_extra(self):
         from . import module

--- a/tests/module.py
+++ b/tests/module.py
@@ -5,4 +5,4 @@ from time import time
 
 
 def get_info():
-    return (time(), datetime.utcnow())
+    return (time(), datetime.now())

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-envlist = py27,py34,py35
+envlist = py36,py37,py38
 
 [testenv]
-deps = -r{toxinidir}/requirements.txt
-commands = python setup.py test
+deps = pytz python-dateutil
+commands = python -m unittest


### PR DESCRIPTION
Make FreezeFrog simulate the time in a system based on first principles.

What are the first principles of time in a computer system? A naive datetime as ticked by the CPU, and its timezone, which the CPU doesn't care about, only the upper layers care about that (the OS, the user, etc).

Therefore, all we need to do to mock a system's time is mock the CPU clock as a naive datetime, and the system's timezone, and all other methods (`utcnow` and friends) can be calculated from there.