### PR TITLE
Make `tz` default to `datetime.timezone.utc`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,10 +37,10 @@ Usage
 
 Use the ``FreezeTime`` context manager to freeze the time. Pass the desired
 ``datetime`` object to the constructor, and the timezone to mock the system's
-timezone. The constructor also takes the ``fold`` argument (``0`` by default),
-which defines whether an ambiguous time refers to its first or second
-appearance, and the ``tick`` argument (``False`` by default), which makes the
-clock start ticking.
+timezone (defaults to `datetime.timzone.utc`). The constructor also takes the
+``fold`` argument (``0`` by default), which defines whether an ambiguous time
+refers to its first or second appearance, and the ``tick`` argument
+(``False`` by default), which makes the clock start ticking.
 
 .. code:: python
 
@@ -48,14 +48,12 @@ clock start ticking.
 
   from freezefrog import FreezeTime
 
-  UTC = datetime.timezone.utc
-
-  with FreezeTime(datetime.datetime(2014, 1, 1), UTC):
+  with FreezeTime(datetime.datetime(2014, 1, 1)):
       # The clock is frozen.
       # Always prints 2014-01-01 00:00:00
       print(datetime.datetime.utcnow())
 
-  with FreezeTime(datetime.datetime(2014, 1, 1), UTC, tick=True):
+  with FreezeTime(datetime.datetime(2014, 1, 1), tick=True):
       # The clock starts ticking immediately.
       # Example output: 2014-01-01 00:00:00.000005
       print(datetime.datetime.utcnow())

--- a/freezefrog/__init__.py
+++ b/freezefrog/__init__.py
@@ -25,7 +25,7 @@ def get_pytz_dst_from_fold(dt, tz, fold):
     datetime's `fold` lets you say you want either the earlier time
     (fold=0) or the later time (fold=1) during the DST transition period.
 
-    pytz's `is_dst` lets you say whether you want to time that was inside the
+    pytz's `is_dst` lets you say whether you want the time that was inside the
     DST interval (the non-standard timezone offset for that region), or outside
     (the standard timezone offset for that region).
 
@@ -135,7 +135,7 @@ class FreezeTime(object):
     def __init__(
         self,
         dt,
-        tz,
+        tz=datetime.timezone.utc,
         fold=0,
         tick=False,
         extra_patch_datetime=(),

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', encoding='utf-8') as file:
 
 setup(
     name='freezefrog',
-    version='0.4.0',
+    version='0.4.1',
     url='http://github.com/closeio/freezefrog',
     license='MIT',
     author='Thomas Steinacher',
@@ -23,11 +23,10 @@ setup(
         'Operating System :: OS Independent',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     packages=[
         'freezefrog',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -15,7 +15,7 @@ TEN_SEC_DELTA = datetime.timedelta(seconds=10)
 
 class FreezeFrogTestCase(unittest.TestCase):
     def test_isinstance(self):
-        with FreezeTime(PAST_DATETIME, pytz.UTC):
+        with FreezeTime(PAST_DATETIME):
             self.assertTrue(
                 isinstance(datetime.datetime.now(), datetime.datetime)
             )
@@ -24,7 +24,7 @@ class FreezeFrogTestCase(unittest.TestCase):
         dt = datetime.datetime.now()
         self.assertTrue(dt > datetime.datetime(2016, 1, 1))
 
-        with FreezeTime(PAST_DATETIME, pytz.UTC):
+        with FreezeTime(PAST_DATETIME):
             time.sleep(0.001)
             self.assertEqual(datetime.datetime.now(), PAST_DATETIME)
             self.assertEqual(datetime.datetime.today(), PAST_DATETIME)
@@ -42,7 +42,7 @@ class FreezeFrogTestCase(unittest.TestCase):
         dt = datetime.datetime.now()
         self.assertTrue(dt > datetime.datetime(2016, 1, 1))
 
-        with FreezeTime(PAST_DATETIME, pytz.UTC, tick=True):
+        with FreezeTime(PAST_DATETIME, tick=True):
             time.sleep(0.001)
             self.assertTrue(
                 PAST_DATETIME
@@ -109,7 +109,7 @@ class FreezeFrogTestCase(unittest.TestCase):
         from . import module
 
         # Doesn't work since we've imported the sample module already.
-        with FreezeTime(PAST_DATETIME, pytz.UTC):
+        with FreezeTime(PAST_DATETIME):
             t, dt = module.get_info()
             self.assertNotEqual(t, PAST_TIME_UTC_TIMESTAMP)
             self.assertNotEqual(dt, PAST_DATETIME)
@@ -117,7 +117,6 @@ class FreezeFrogTestCase(unittest.TestCase):
         # Works as expected.
         with FreezeTime(
             PAST_DATETIME,
-            pytz.UTC,
             extra_patch_time=["tests.module.time"],
             extra_patch_datetime=["tests.module.datetime"],
         ):


### PR DESCRIPTION
Make `tz` default to `datetime.timezone.utc` to allow for less verbose code.